### PR TITLE
Делаем чёрный не слишком чёрным

### DIFF
--- a/Universal.bundle/Contents/Info.plist
+++ b/Universal.bundle/Contents/Info.plist
@@ -14,6 +14,8 @@
 		<string>me.tonsky.keyboardlayout.universal.english-universal</string>
 		<key>TISIntendedLanguage</key>
 		<string>en</string>
+		<key>TISIconIsTemplate</key>
+		<true/>
 	</dict>
 	<key>KLInfo_English - Universal Dark</key>
 	<dict>
@@ -21,6 +23,8 @@
 		<string>me.tonsky.keyboardlayout.universal.english-universaldark</string>
 		<key>TISIntendedLanguage</key>
 		<string>en</string>
+		<key>TISIconIsTemplate</key>
+		<true/>
 	</dict>
 	<key>KLInfo_Russian - Universal</key>
 	<dict>


### PR DESCRIPTION
Вы верно заметили, что в обычных приложениях, которые добавляют свои иконки в менюбар, у разработчиков есть возможность подсунуть macOS’у простую png’шку с выставленным в коде флагом isTemplate = true — и тот будет использовать её как «шаблон»: от картинки возьмёт только прозрачность пикселей, а цвет выберет на своё усмотрение.

Но у вас тут не приложение, поэтому непонятно, где выставлять этот флаг. Отвечаю: прямо в Info.plist. Этот флаг (TISIconIsTemplate) нигде не задокументирован, поэтому никаких гарантий, что он будет работать в будущем, нет 🤞

Результат:
![template](https://user-images.githubusercontent.com/5719520/55631787-86992980-57c1-11e9-94d9-98233752e3e1.png)

P.S. Наверное, теперь можно убрать отдельные версии раскладки для Light и Dark тем — иконка нормально адаптируется под обе темы самостоятельно.