### PR TITLE
Восстановлено переключение раскладки по  Caps Lock

### DIFF
--- a/Universal.bundle/Contents/Info.plist
+++ b/Universal.bundle/Contents/Info.plist
@@ -10,21 +10,21 @@
 	<string>1.1</string>
 	<key>KLInfo_English - Universal</key>
 	<dict>
+		<key>TICapsLockLanguageSwitchCapable</key>
+		<false/>
 		<key>TISInputSourceID</key>
 		<string>me.tonsky.keyboardlayout.universal.english-universal</string>
 		<key>TISIntendedLanguage</key>
 		<string>en</string>
-		<key>TISIconIsTemplate</key>
-		<true/>
 	</dict>
 	<key>KLInfo_Russian - Universal</key>
 	<dict>
+		<key>TICapsLockLanguageSwitchCapable</key>
+		<true/>
 		<key>TISInputSourceID</key>
 		<string>me.tonsky.keyboardlayout.universal.russian-universal</string>
 		<key>TISIntendedLanguage</key>
 		<string>ru</string>
-		<key>TISCapsLockIsSwitch</key>
-		<true/>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Решение проблемы #25 

Восстановлено переключение раскладки по Caps Lock для macos Catalina. Собственно, открыл в Ukelele новой версии и в окошке параметров бандла поставил галочку "Caps Lock Switch".